### PR TITLE
Fix example script: use location instead of undefined var site

### DIFF
--- a/example
+++ b/example
@@ -12,7 +12,7 @@ do
         end tell"
     else
         if command -v xterm >/dev/null 2>&1; then
-            xterm -title $site -e "./example-location $location" &
+            xterm -title $location -e "./example-location $location" &
         else
             echo "Neiter osascript nor xterm were found";
         fi


### PR DESCRIPTION
Without this `./example A B C` failed with `./example: line 15: site: unbound variable`.

Great template/example btw!
